### PR TITLE
Added kitchen-dokken testing for faster feedback with a lighter footprint

### DIFF
--- a/jenkins_wrapper_cookbook/.gitignore
+++ b/jenkins_wrapper_cookbook/.gitignore
@@ -16,5 +16,6 @@ Gemfile.lock
 bin/*
 .bundle/*
 
+nodes/*
 .kitchen/
 .kitchen.local.yml

--- a/jenkins_wrapper_cookbook/.kitchen.yml
+++ b/jenkins_wrapper_cookbook/.kitchen.yml
@@ -2,7 +2,6 @@
 driver:
   name: dokken
   chef_version: latest
-  privileged: true
 
 provisioner:
   name: dokken
@@ -25,6 +24,12 @@ platforms:
       pid_one_command: /sbin/init
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      seccomp: unconfined
+      tmpfs:
+         - "/run"
+         - "/run/lock"
+      cap_add:
+         - SYS_ADMIN
 
 suites:
   - name: default

--- a/jenkins_wrapper_cookbook/.kitchen.yml
+++ b/jenkins_wrapper_cookbook/.kitchen.yml
@@ -1,0 +1,33 @@
+---
+driver:
+  name: dokken
+  chef_version: latest
+  privileged: true
+
+provisioner:
+  name: dokken
+  data_bags_path: "data_bags"
+  environments_path: "environments"
+  client_rb:
+    environment: 'dev'
+
+transport:
+  name: dokken
+
+platforms:
+  - name: ubuntu-14.04
+    driver:
+      image: dokken/ubuntu-14.04
+      pid_one_command: /sbin/init
+  - name: ubuntu-18.04
+    driver:
+      image: dokken/ubuntu-18.04
+      pid_one_command: /sbin/init
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+suites:
+  - name: default
+    run_list:
+      - recipe[jenkins_wrapper_cookbook::default]
+    attributes:

--- a/jenkins_wrapper_cookbook/Vagrantfile
+++ b/jenkins_wrapper_cookbook/Vagrantfile
@@ -47,6 +47,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     chef.data_bags_path = 'data_bags'
     chef.environments_path = 'environments'
     chef.nodes_path = 'nodes'
+    # Need to clean 'nodes' before each provision otherwise it uses existing data
+    if File.exist?(chef.nodes_path)
+      if File.directory?(chef.nodes_path)
+          Dir.foreach(chef.nodes_path) do |file|
+            if ((file.to_s != ".")\
+              and (file.to_s != "..")\
+              and (file.to_s != ".gitignore"))
+                File.delete("#{chef.nodes_path}/#{file}")
+            end
+          end
+      end
+    end
 
     chef.environment = 'dev'
     chef.add_recipe('jenkins_wrapper_cookbook')

--- a/jenkins_wrapper_cookbook/attributes/default.rb
+++ b/jenkins_wrapper_cookbook/attributes/default.rb
@@ -1,5 +1,5 @@
 default['java']['install_flavor'] = 'oracle'
-default['java']['jdk_version'] = '7'
+default['java']['jdk_version'] = '8'
 default['java']['oracle']['accept_oracle_download_terms'] = true
 
 default['jenkins']['master']['install_method'] = 'war'
@@ -10,7 +10,9 @@ default['jenkins_wrapper_cookbook'].tap do |jenkins_wrapper|
   jenkins_wrapper['plugins'] = {
       'active-directory' => true,
       'credentials' => true,
-      'git' => true,
+      'git' => {
+          'version' => '3.9.1'
+      },
       'git-client' => true,
       'matrix-auth' => true,
       'job-dsl' => {

--- a/jenkins_wrapper_cookbook/nodes/.gitignore
+++ b/jenkins_wrapper_cookbook/nodes/.gitignore
@@ -1,0 +1,2 @@
+# This file exists to allow checking in the empty directory required by Chef-zero
+*

--- a/jenkins_wrapper_cookbook/recipes/default.rb
+++ b/jenkins_wrapper_cookbook/recipes/default.rb
@@ -4,6 +4,7 @@
 # This ensures stale apt indexes don't fail package installations
 apt_update 'run update' do
   action :nothing
+  only_if { platform_family?('debian') }
 end.run_action(:update)
 
 include_recipe 'java'

--- a/jenkins_wrapper_cookbook/recipes/default.rb
+++ b/jenkins_wrapper_cookbook/recipes/default.rb
@@ -1,10 +1,21 @@
 ###############################################################################
 # Install server dependencies
 ###############################################################################
+# This ensures stale apt indexes don't fail package installations
+apt_update 'run update' do
+  action :nothing
+end.run_action(:update)
+
 include_recipe 'java'
 python_runtime '2'
 include_recipe 'git'
 package 'unzip'
+
+## Using the package is tricky as some distributions have old versions you need
+## a PPA or EPEL repo to do it "safely"
+# package 'gradle'
+## There IS a Gradle cookbook, but the published one is ancient, and the updated
+## one isn't published
 
 execute 'install_gradle' do
   command <<-EOH.gsub(/^ {4}/,'')
@@ -86,7 +97,7 @@ end
 
 execute 'install_plugins' do
   command <<-EOH.gsub(/^ {4}/,'')
-  source /etc/profile
+  . /etc/profile
   gradle install && gradle dependencies > 'plugins.lock'
   EOH
   user node['jenkins']['master']['user']


### PR DESCRIPTION
Currently it is running two containers so slightly heavier than just testing with 18.04, but it ensures pre-systemd and systemd compatibility.

Only requirements in this case is Docker and the ChefDK, no need for Vagrant + Virtualbox and a bunch of plugins for Vagrant.